### PR TITLE
feat: add astro meetup site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+pnpm-lock.yaml
+

--- a/meetup-astro/.gitignore
+++ b/meetup-astro/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+dist

--- a/meetup-astro/README.md
+++ b/meetup-astro/README.md
@@ -1,0 +1,5 @@
+# Meetup Astro Site
+
+A simple Astro site describing the Tulsa Web Devs meetup.
+
+Deploy on Netlify using the included `netlify.toml`.

--- a/meetup-astro/astro.config.mjs
+++ b/meetup-astro/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import netlify from '@astrojs/netlify';
+
+export default defineConfig({
+output: 'server',
+adapter: netlify(),
+});

--- a/meetup-astro/netlify.toml
+++ b/meetup-astro/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = "dist"

--- a/meetup-astro/package.json
+++ b/meetup-astro/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "meetup-astro",
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "astro": "^4.0.0",
+    "@astrojs/netlify": "^5.0.0"
+  }
+}

--- a/meetup-astro/src/pages/index.astro
+++ b/meetup-astro/src/pages/index.astro
@@ -1,0 +1,30 @@
+---
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tulsa Web Devs Meetup</title>
+  </head>
+  <body>
+    <main>
+      <h1>Tulsa Web Devs Meetup</h1>
+      <p>Tulsa Web Devs meetups are intended to bring together technologists from across a wide range of languages and disciplines. From back-end development in various languages to front-end technologies like HTML, CSS, and JavaScript, to web-adjacent fields like data science and civic tech—we aim to learn, share, build, and grow together.</p>
+      <h2>Agent Coding Crash Course: Managing your AI Team Part 2</h2>
+      <p>Transform your coding process with an AI coworker in three key ideas: clear collaboration guidelines, smart interaction modes, and embedding continuous learning into your code.</p>
+      <ul>
+        <li>Clear Guidelines: Set up user and project rules to make AI interactions effective.</li>
+        <li>Choosing Interaction Modes: Understand when to use chat auto-run vs. manual model selection.</li>
+        <li>Embedding AI Behavior: Integrate linting rules, comprehensive comments, READMEs, tests, and runtime assertions right into your code.</li>
+        <li>Iterative Improvement: Document new insights continuously, turning your code into a long-term memory for smarter, future-focused development.</li>
+      </ul>
+      <p>This event is perfect for developers of all experience levels—whether you want to dig into code, ask questions, or just listen in.</p>
+      <p><strong>Location:</strong> 7 N Cheyenne (Beside Atlas School, across from Gradient)</p>
+      <p><strong>Date &amp; Time:</strong> June 24 · 6:00 PM CST</p>
+      <p><strong>Speaker:</strong> Sam Carlton</p>
+      <p><strong>Bring a laptop if you’d like to follow along</strong></p>
+      <p>Pizza &amp; drinks will be provided (please RSVP so we can plan the order)</p>
+      <p>Expect a friendly, casual environment focused on practical knowledge you can apply to your projects right away. See you there—we can’t wait to explore Cursor IDE together!</p>
+    </main>
+  </body>
+</html>

--- a/meetup-astro/tsconfig.json
+++ b/meetup-astro/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "astro/tsconfigs/base"
+}

--- a/package.json
+++ b/package.json
@@ -1,19 +1,23 @@
 {
-	"name": "codex-starter",
-	"version": "1.0.0",
-	"description": "",
-	"main": "index.js",
-	"scripts": {
-		"lint": "biome check --write",
-		"typecheck": "tsc --noEmit",
-		"biome:changes": "git diff --name-only HEAD | grep -E '\\.(js|jsx|ts|tsx|json|jsonc)$' | xargs -r biome",
-		"lint:changes": "pnpm biome:changes lint",
-		"format:changes": "pnpm biome:changes format --write",
-		"check:changes": "pnpm biome:changes check --apply",
-		"ai-lint:changes": "pnpm biome:changes lint --config-path ./biome.ai.jsonc"
-	},
-	"keywords": [],
-	"author": "",
-	"license": "ISC",
-	"packageManager": "pnpm@10.11.0"
+  "name": "codex-starter",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "lint": "biome check --write",
+    "typecheck": "tsc --noEmit",
+    "biome:changes": "git diff --name-only HEAD | grep -E '\\.(js|jsx|ts|tsx|json|jsonc)$' | xargs -r biome",
+    "lint:changes": "pnpm biome:changes lint",
+    "format:changes": "pnpm biome:changes format --write",
+    "check:changes": "pnpm biome:changes check --apply",
+    "ai-lint:changes": "pnpm biome:changes lint --config-path ./biome.ai.jsonc"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.11.0",
+  "devDependencies": {
+    "biome": "^0.3.3",
+    "typescript": "^5.4.0"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "allowJs": true
+  }
+}


### PR DESCRIPTION
## Summary
- create `meetup-astro` Astro project with Netlify adapter
- add meetup info content in `index.astro`
- provide Netlify build configuration
- set up root tooling and configs for Biome and TypeScript
- add project level `tsconfig.json`

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm ai-lint:changes`


------
https://chatgpt.com/codex/tasks/task_e_685b2b01145c83319ccba00fb1fd4983